### PR TITLE
Add compile_blocks_from_info_v2 and updates to activation and behavior scripts

### DIFF
--- a/Activation/Instructions for extracting data from Tseries.txt
+++ b/Activation/Instructions for extracting data from Tseries.txt
@@ -8,3 +8,5 @@
 6. Run extract_ROI_data_from_Fall
 	(navigate to current Fall.mat folder first)
 	(change runID)
+7. Run plot_ROI_data_from_Fall to plot peak of activation vs. power
+	(modify cell number, run, and power)

--- a/Activation/extractYfromTseries.m
+++ b/Activation/extractYfromTseries.m
@@ -1,6 +1,6 @@
 %Script to extract y from t-series
 
-mouse_dir = '\\apollo\research\ENT\Takesian Lab\Maryse\2p data\NxDE072420M2\2020-11-19';
+mouse_dir = '\\apollo\research\ENT\Takesian Lab\Maryse\2p data\YE083020F2\2020-12-02';
 cd(mouse_dir)
 currentFolders = dir;
 

--- a/Activation/extract_ROI_data_from_Fall.m
+++ b/Activation/extract_ROI_data_from_Fall.m
@@ -5,7 +5,7 @@
 %Load Tseries data
 
 Fall = load('Fall.mat'); %Must load like this because iscell is a matlab function and might lead to unexpected errors.
-currentRunID = 8;
+currentRunID = 4;
 
 %% Extract info by cycle
 currentRunName = data.Folders{currentRunID,1};
@@ -96,10 +96,10 @@ nPlots = floor(sqrt(nCells));
 figure; subplot(nPlots,nPlots,1);
 suptitle(currentRunName)
 for c = 1:nCells
-    if c > nPlots^2
-        continue
-    end
-    subplot(nPlots,nPlots,c); hold on
+%     if c > nPlots^2
+%         continue
+%     end
+    subplot(nPlots,nPlots+1,c); hold on
     title(['Cell #' num2str(block.cell_number(c))])
     plot(1:size(avgTrialMat,2),avgTrialMat(c,:))
     line([baselineDuration, baselineDuration], [0 2], 'Color', 'r')

--- a/Activation/plot_ROI_data_from_Fall.m
+++ b/Activation/plot_ROI_data_from_Fall.m
@@ -1,0 +1,131 @@
+%plot_ROI_data_from_Fall
+
+Fall = load('Fall.mat'); %Must load like this because iscell is a matlab function and might lead to unexpected errors.
+
+cellsToPlot = [11, 11, 11,11,11,11,11,11,11,11,11];
+runIDsToPlot = [6,7,8,9,10,11,5,2,3,4,1];
+power = [10,20,30,50,70,80,100,30,50,80,100];
+peak = nan(1,3);
+
+for r = 1:length(runIDsToPlot)
+    
+    currentRunID = runIDsToPlot(r);
+    currentCellToPlot = cellsToPlot(r);
+
+    %% Extract info by cycle
+    currentRunName = data.Folders{currentRunID,1};
+    xMat = data.xMats{currentRunID,1};
+    nFrames = size(xMat,2);
+
+    % Cycles = Baseline -> Mark points -> Activation... Repeat
+    cycleNumbers = unique(xMat(1,:));
+    baseline = 1:3:(cycleNumbers(end)); %t-series always starts with baseline
+    activation = 3:3:(cycleNumbers(end));
+
+    %Set new baseline vs. activation parameter
+    xMat(3,:) = 0;
+    for i = 1:length(activation)
+        xMat(3,xMat(1,:) == activation(i)) = 1;
+    end
+
+    baselineDuration = max(xMat(2,xMat(3,:) == 0));
+    activationDuration = max(xMat(2,xMat(3,:) == 1));
+    markPoints = baselineDuration:(baselineDuration + activationDuration):nFrames;
+
+    %% Extract ROI data from Fall
+
+    [Frame_set,~] = get_frames_from_Fall(Fall.ops, currentRunName, 1);
+    %Cell and neuropil data
+    %Only keep data from 'is cells' within the block's frame set
+    block.iscell = Fall.iscell;
+    keep_ind = find(block.iscell(:,1));
+    block.cell_number = keep_ind-1; %Subtract 1 for the python to matlab correction of cell label
+    block.stat = Fall.stat(1,keep_ind);
+    block.F = Fall.F(keep_ind,Frame_set);
+    block.Fneu = Fall.Fneu(keep_ind,Frame_set);
+    block.spks = Fall.spks(keep_ind,Frame_set);
+    block.F7 = block.F - 0.7*block.Fneu;
+
+    if isfield(Fall, 'redcell')
+        redcell = Fall.redcell; %Not all runs will have red cells
+        block.redcell = redcell(keep_ind);
+    else
+        block.redcell = nan;
+    end
+
+%% Plot graph of raw traces
+
+%DF/F
+mean_of_full_trace = mean(block.F7,2);
+block.F7_df_f = (block.F7-mean_of_full_trace)./mean_of_full_trace; %(total-mean)/mean
+
+count = 0;
+% 
+% figure; hold on
+% for p = 1:size(block.F7_df_f,1) 
+%     plot((1:nFrames),block.F7_df_f(p,1:nFrames) + count)
+%     count = count + 2;
+% end
+% title(currentRunName)
+% vline(markPoints)
+% %ylim([0 21])
+% xlim([0,nFrames])
+
+%% Make average mats
+
+nCells = size(block.F7_df_f,1);
+
+baselineMat = nan(nCells,baselineDuration,length(baseline));
+activationMat = nan(nCells,activationDuration,length(baseline));
+ 
+for b = 1:length(baseline)
+    for c = 1:nCells
+    baselineMat(c,:,b) = block.F7_df_f(c, find(xMat(1,:) == baseline(b)));
+    end
+end
+
+for a = 1:length(activation)
+    for c = 1:nCells
+    activationMat(c,:,a) = block.F7_df_f(c, find(xMat(1,:) == activation(a)));
+    end
+end
+
+%average by trial
+baselineMat = mean(baselineMat,3);
+activationMat = mean(activationMat,3);
+avgTrialMat = [baselineMat, activationMat];
+
+activation_peaks = max(activationMat,[],2);
+cellInd = find(block.cell_number == currentCellToPlot);
+peak(r) = activation_peaks(cellInd);
+
+
+
+% 
+% %Figure
+% nPlots = floor(sqrt(nCells));
+% 
+% figure; subplot(nPlots,nPlots,1);
+% suptitle(currentRunName)
+% for c = 1:nCells
+%     if c > nPlots^2
+%         continue
+%     end
+%     subplot(nPlots,nPlots,c); hold on
+%     title(['Cell #' num2str(block.cell_number(c))])
+%     plot(1:size(avgTrialMat,2),avgTrialMat(c,:))
+%     line([baselineDuration, baselineDuration], [0 2], 'Color', 'r')
+%     xlim([0 size(avgTrialMat,2)])
+%     ylabel('F7')
+%     xlabel('Frames')
+% end
+
+end
+
+figure
+bar(peak)
+ylabel('Peak dff')
+xlabel('Power')
+set(gca, 'XTick', 1:length(power))
+set(gca, 'XTickLabel', power)
+title('YE083020F2 Cell 2')

--- a/Dependencies/parseXML.m
+++ b/Dependencies/parseXML.m
@@ -1,0 +1,70 @@
+function theStruct = parseXML(filename)
+% PARSEXML Convert XML file to a MATLAB structure.
+try
+   tree = xmlread(filename);
+catch
+   error('Failed to read XML file %s.',filename);
+end
+
+% Recurse over child nodes. This could run into problems 
+% with very deeply nested trees.
+try
+   theStruct = parseChildNodes(tree);
+catch
+   error('Unable to parse XML file %s.',filename);
+end
+
+
+% ----- Local function PARSECHILDNODES -----
+function children = parseChildNodes(theNode)
+% Recurse over node children.
+children = [];
+if theNode.hasChildNodes
+   childNodes = theNode.getChildNodes;
+   numChildNodes = childNodes.getLength;
+   allocCell = cell(1, numChildNodes);
+
+   children = struct(             ...
+      'Name', allocCell, 'Attributes', allocCell,    ...
+      'Data', allocCell, 'Children', allocCell);
+
+    for count = 1:numChildNodes
+        theChild = childNodes.item(count-1);
+        children(count) = makeStructFromNode(theChild);
+    end
+end
+
+% ----- Local function MAKESTRUCTFROMNODE -----
+function nodeStruct = makeStructFromNode(theNode)
+% Create structure of node info.
+
+nodeStruct = struct(                        ...
+   'Name', char(theNode.getNodeName),       ...
+   'Attributes', parseAttributes(theNode),  ...
+   'Data', '',                              ...
+   'Children', parseChildNodes(theNode));
+
+if any(strcmp(methods(theNode), 'getData'))
+   nodeStruct.Data = char(theNode.getData); 
+else
+   nodeStruct.Data = '';
+end
+
+% ----- Local function PARSEATTRIBUTES -----
+function attributes = parseAttributes(theNode)
+% Create attributes structure.
+
+attributes = [];
+if theNode.hasAttributes
+   theAttributes = theNode.getAttributes;
+   numAttributes = theAttributes.getLength;
+   allocCell = cell(1, numAttributes);
+   attributes = struct('Name', allocCell, 'Value', ...
+                       allocCell);
+
+   for count = 1:numAttributes
+      attrib = theAttributes.item(count-1);
+      attributes(count).Name = char(attrib.getName);
+      attributes(count).Value = char(attrib.getValue);
+   end
+end

--- a/Dependencies/xml2struct.m
+++ b/Dependencies/xml2struct.m
@@ -1,0 +1,174 @@
+function [ s ] = xml2struct( file )
+%Convert xml file into a MATLAB structure
+% [ s ] = xml2struct( file )
+%
+% A file containing:
+% <XMLname attrib1="Some value">
+%   <Element>Some text</Element>
+%   <DifferentElement attrib2="2">Some more text</Element>
+%   <DifferentElement attrib3="2" attrib4="1">Even more text</DifferentElement>
+% </XMLname>
+%
+% Will produce:
+% s.XMLname.Attributes.attrib1 = "Some value";
+% s.XMLname.Element.Text = "Some text";
+% s.XMLname.DifferentElement{1}.Attributes.attrib2 = "2";
+% s.XMLname.DifferentElement{1}.Text = "Some more text";
+% s.XMLname.DifferentElement{2}.Attributes.attrib3 = "2";
+% s.XMLname.DifferentElement{2}.Attributes.attrib4 = "1";
+% s.XMLname.DifferentElement{2}.Text = "Even more text";
+%
+% Please note that the following characters are substituted
+% '-' by '_dash_', ':' by '_colon_' and '.' by '_dot_'
+%
+% Written by W. Falkena, ASTI, TUDelft, 21-08-2010
+% Attribute parsing speed increased by 40% by A. Wanner, 14-6-2011
+% Added CDATA support by I. Smirnov, 20-3-2012
+%
+% Modified by X. Mo, University of Wisconsin, 12-5-2012
+    if (nargin < 1)
+        clc;
+        help xml2struct
+        return
+    end
+    
+    if isa(file, 'org.apache.xerces.dom.DeferredDocumentImpl') || isa(file, 'org.apache.xerces.dom.DeferredElementImpl')
+        % input is a java xml object
+        xDoc = file;
+    else
+        %check for existance
+        if (exist(file,'file') == 0)
+            %Perhaps the xml extension was omitted from the file name. Add the
+            %extension and try again.
+            if (isempty(strfind(file,'.xml')))
+                file = [file '.xml'];
+            end
+            
+            if (exist(file,'file') == 0)
+                error(['The file ' file ' could not be found']);
+            end
+        end
+        %read the xml file
+        xDoc = xmlread(file);
+    end
+    
+    %parse xDoc into a MATLAB structure
+    s = parseChildNodes(xDoc);
+    
+end
+% ----- Subfunction parseChildNodes -----
+function [children,ptext,textflag] = parseChildNodes(theNode)
+    % Recurse over node children.
+    children = struct;
+    ptext = struct; textflag = 'Text';
+    if hasChildNodes(theNode)
+        childNodes = getChildNodes(theNode);
+        numChildNodes = getLength(childNodes);
+        for count = 1:numChildNodes
+            theChild = item(childNodes,count-1);
+            [text,name,attr,childs,textflag] = getNodeData(theChild);
+            
+            if (~strcmp(name,'#text') && ~strcmp(name,'#comment') && ~strcmp(name,'#cdata_dash_section'))
+                %XML allows the same elements to be defined multiple times,
+                %put each in a different cell
+                if (isfield(children,name))
+                    if (~iscell(children.(name)))
+                        %put existsing element into cell format
+                        children.(name) = {children.(name)};
+                    end
+                    index = length(children.(name))+1;
+                    %add new element
+                    children.(name){index} = childs;
+                    if(~isempty(fieldnames(text)))
+                        children.(name){index} = text; 
+                    end
+                    if(~isempty(attr)) 
+                        children.(name){index}.('Attributes') = attr; 
+                    end
+                else
+                    %add previously unknown (new) element to the structure
+                    children.(name) = childs;
+                    if(~isempty(text) && ~isempty(fieldnames(text)))
+                        children.(name) = text; 
+                    end
+                    if(~isempty(attr)) 
+                        children.(name).('Attributes') = attr; 
+                    end
+                end
+            else
+                ptextflag = 'Text';
+                if (strcmp(name, '#cdata_dash_section'))
+                    ptextflag = 'CDATA';
+                elseif (strcmp(name, '#comment'))
+                    ptextflag = 'Comment';
+                end
+                
+                %this is the text in an element (i.e., the parentNode) 
+                if (~isempty(regexprep(text.(textflag),'[\s]*','')))
+                    if (~isfield(ptext,ptextflag) || isempty(ptext.(ptextflag)))
+                        ptext.(ptextflag) = text.(textflag);
+                    else
+                        %what to do when element data is as follows:
+                        %<element>Text <!--Comment--> More text</element>
+                        
+                        %put the text in different cells:
+                        % if (~iscell(ptext)) ptext = {ptext}; end
+                        % ptext{length(ptext)+1} = text;
+                        
+                        %just append the text
+                        ptext.(ptextflag) = [ptext.(ptextflag) text.(textflag)];
+                    end
+                end
+            end
+            
+        end
+    end
+end
+% ----- Subfunction getNodeData -----
+function [text,name,attr,childs,textflag] = getNodeData(theNode)
+    % Create structure of node info.
+    
+    %make sure name is allowed as structure name
+    name = toCharArray(getNodeName(theNode))';
+    name = strrep(name, '-', '_dash_');
+    name = strrep(name, ':', '_colon_');
+    name = strrep(name, '.', '_dot_');
+    attr = parseAttributes(theNode);
+    if (isempty(fieldnames(attr))) 
+        attr = []; 
+    end
+    
+    %parse child nodes
+    [childs,text,textflag] = parseChildNodes(theNode);
+    
+    if (isempty(fieldnames(childs)) && isempty(fieldnames(text)))
+        %get the data of any childless nodes
+        % faster than if any(strcmp(methods(theNode), 'getData'))
+        % no need to try-catch (?)
+        % faster than text = char(getData(theNode));
+        text.(textflag) = toCharArray(getTextContent(theNode))';
+    end
+    
+end
+% ----- Subfunction parseAttributes -----
+function attributes = parseAttributes(theNode)
+    % Create attributes structure.
+    attributes = struct;
+    if hasAttributes(theNode)
+       theAttributes = getAttributes(theNode);
+       numAttributes = getLength(theAttributes);
+       for count = 1:numAttributes
+            %attrib = item(theAttributes,count-1);
+            %attr_name = regexprep(char(getName(attrib)),'[-:.]','_');
+            %attributes.(attr_name) = char(getValue(attrib));
+            %Suggestion of Adrian Wanner
+            str = toCharArray(toString(item(theAttributes,count-1)))';
+            k = strfind(str,'='); 
+            attr_name = str(1:(k(1)-1));
+            attr_name = strrep(attr_name, '-', '_dash_');
+            attr_name = strrep(attr_name, ':', '_colon_');
+            attr_name = strrep(attr_name, '.', '_dot_');
+            attributes.(attr_name) = str((k(1)+2):(end-1));
+       end
+    end
+end

--- a/Dependencies/xml2struct.m
+++ b/Dependencies/xml2struct.m
@@ -104,7 +104,7 @@ function [children,ptext,textflag] = parseChildNodes(theNode)
                 end
                 
                 %this is the text in an element (i.e., the parentNode) 
-                if (~isempty(regexprep(text.(textflag),'[\s]*','')))
+                if ~all(isspace(text.(textflag)))%(~isempty(regexprep(text.(textflag),'[\s]*','')))
                     if (~isfield(ptext,ptextflag) || isempty(ptext.(ptextflag)))
                         ptext.(ptextflag) = text.(textflag);
                     else

--- a/align_to_stim.m
+++ b/align_to_stim.m
@@ -48,74 +48,130 @@ if nargin == 2
     setup.constant.after_stim = 3;
 end
 
+%generate a neuropil corrected trace  = raw F - (neuropil coefficient)*neuropil signal
+F7 = block.F - setup.constant.neucoeff*block.Fneu;
+ 
+%Preallocate variables and trial length in frames
+%Align everything to closest frame to sound start
+baseline_inFrames = setup.constant.baseline_length*block.setup.framerate;
+after_inFrames = setup.constant.after_stim*block.setup.framerate;
+duration_inFrames = baseline_inFrames + after_inFrames;
+
+nanMat = nan(size(block.F,1),length(Sound_Time),duration_inFrames);
+F7_stim = nanMat;
+F_stim = nanMat;
+Fneu_stim = nanMat;
+spks_stim = nanMat;
+
 % loop through each stim-presenation
 for time=1:length(Sound_Time)
    
     sound = Sound_Time(time);
-    
-    % define when baseline starts
-    before = Sound_Time(time)-setup.constant.baseline_length;
-    
-    % define the end time of the trace
-    after = Sound_Time(time)+setup.constant.after_stim;
-    
-    %define the "response window" (stim presentation to end of expected
-    %trace)
-    window = Sound_Time(time)+setup.constant.response_window; 
-
-    
-    % find the frames that correspond to the above times. This will give
-    % you four frame numbers per stim. 1) start baseline 2) stim 3) end of
-    % the response window 4) end of the trace
-    [c closest_frame_before] = min(abs(block.timestamp(:)-before));
-    [c closest_frame_sound] = min(abs(block.timestamp(:)-sound));
-    [c closest_frame_after] = min(abs(block.timestamp(:)-after));
-    [c closest_frame_window] = min(abs(block.timestamp(:)-window));
-    
-    % how long is the entire trace (in frames)?
-    length_sound_trial(time) = closest_frame_after-closest_frame_before;
-    % how long is the response window (in frames)?
-    length_sound_window(time) = closest_frame_window-closest_frame_sound;
-    
-   % sometimes, the length of the trials are off by one frame due to how we
-   % calculate the frame times. Below, we correct for this by making every
-   % trace the same as time=1
-    if time>1
-        difference_length_sound_trial(time) = length_sound_trial(time)-length_sound_trial_first;
-        closest_frame_after = closest_frame_after-difference_length_sound_trial(time);
-        difference_length_window(time) = length_sound_window(time)-length_sound_window(1);
-        closest_frame_window = closest_frame_window-difference_length_window(time);
-        
-    else
-        length_sound_trial_first = length_sound_trial(time);
-    end
+    [~, closest_frame_sound] = min(abs(block.timestamp(:)-sound));
+    A = closest_frame_sound - baseline_inFrames;
+    B = closest_frame_sound + after_inFrames - 1;
     
     % loop through each "iscell" to find the stim-aligned 1) raw
     % fluoresence 2) neuropil signal 3) neuropil-corrected floresence 4)
     % df/F for the neuropil corrected fluoresence 5) deconvolved spikes
     for k = 1:size(block.F,1)
-        %generate a neuropil corrected trace 
-        % neuropil corrected trace = raw F - (neuropil
-        % coefficient)*neuropil signal
-        F7 = block.F(k,:) - setup.constant.neucoeff*block.Fneu(k,:);
-        
-        % pull out the frames aligned to a stim (defined in frames)
-        F7_stim(k,time,:) = (F7(closest_frame_before:closest_frame_after));
-        F_stim(k,time,:) =  block.F(k,closest_frame_before:closest_frame_after);
-        Fneu_stim(k,time,:) = block.Fneu(k,closest_frame_before:closest_frame_after);
-        spks_stim(k,time,:) = block.spks(k,closest_frame_before:closest_frame_after);
 
-        %df/f
-%         baseline_mean = mean(F7(closest_frame_before:closest_frame_sound));
-%         F7_dfF_stim(k,time,:) = (bsxfun(@minus, raw_trace(k,time,:),baseline_mean))./baseline_mean;
+        %If user-defined trial is longer than block recording, take portion
+        %of trial up to the end of recording, the rest of the frames will be nan
+        b = duration_inFrames;
+        B = closest_frame_sound + after_inFrames - 1;
+        if B > size(F7,2)
+            B = size(F7,2);
+            b = length(A:B);
+        end
+        % pull out the frames aligned to a stim (defined in frames)
+        F7_stim(k,time,1:b) = F7(k,A:B);
+        F_stim(k,time,1:b) =  block.F(k,A:B);
+        Fneu_stim(k,time,1:b) = block.Fneu(k,A:B);
+        spks_stim(k,time,1:b) = block.spks(k,A:B);
     end
 end
-%  block.aligned_stim.F7_dfF_stim = F7_dfF_stim;
+
  block.aligned_stim.F7_stim = F7_stim;
  block.aligned_stim.F_stim = F_stim;
  block.aligned_stim.Fneu_stim = Fneu_stim;
  block.aligned_stim.spks_stim = spks_stim;
  
 end
+
+%% PREVIOUS CODE
+
+
+% % loop through each stim-presenation
+% for time=1:length(Sound_Time)
+%    
+%     sound = Sound_Time(time);
+%     
+%     % define when baseline starts
+%     before = Sound_Time(time)-setup.constant.baseline_length;
+%     
+%     % define the end time of the trace
+%     after = Sound_Time(time)+setup.constant.after_stim;
+%     
+%     %define the "response window" (stim presentation to end of expected
+%     %trace)
+%     window = Sound_Time(time)+setup.constant.response_window; 
+% 
+%     
+%     % find the frames that correspond to the above times. This will give
+%     % you four frame numbers per stim. 1) start baseline 2) stim 3) end of
+%     % the response window 4) end of the trace
+%     [c closest_frame_before] = min(abs(block.timestamp(:)-before));
+%     [c closest_frame_sound] = min(abs(block.timestamp(:)-sound));
+%     [c closest_frame_after] = min(abs(block.timestamp(:)-after));
+%     [c closest_frame_window] = min(abs(block.timestamp(:)-window));
+%     
+%     % how long is the entire trace (in frames)?
+%     length_sound_trial(time) = closest_frame_after-closest_frame_before;
+%     % how long is the response window (in frames)?
+%     length_sound_window(time) = closest_frame_window-closest_frame_sound;
+%     
+%    % sometimes, the length of the trials are off by one frame due to how we
+%    % calculate the frame times. Below, we correct for this by making every
+%    % trace the same as trial 1
+%     if time>1
+%         difference_length_sound_trial(time) = length_sound_trial(time)-length_sound_trial_first;
+%         closest_frame_after = closest_frame_after-difference_length_sound_trial(time);
+%         difference_length_window(time) = length_sound_window(time)-length_sound_window(1);
+%         closest_frame_window = closest_frame_window-difference_length_window(time);
+%         
+%     else
+%         length_sound_trial_first = length_sound_trial(time);
+%     end
+%     
+%     % loop through each "iscell" to find the stim-aligned 1) raw
+%     % fluoresence 2) neuropil signal 3) neuropil-corrected floresence 4)
+%     % df/F for the neuropil corrected fluoresence 5) deconvolved spikes
+%     for k = 1:size(block.F,1)
+%         %generate a neuropil corrected trace 
+%         % neuropil corrected trace = raw F - (neuropil
+%         % coefficient)*neuropil signal
+%         F7 = block.F(k,:) - setup.constant.neucoeff*block.Fneu(k,:);
+%         
+%         % pull out the frames aligned to a stim (defined in frames)
+%         if closest_frame_after > size(F7,2)
+%             closest_frame_after = size(F7,2);
+%         end
+%         F7_stim(k,time,:) = (F7(closest_frame_before:closest_frame_after));
+%         F_stim(k,time,:) =  block.F(k,closest_frame_before:closest_frame_after);
+%         Fneu_stim(k,time,:) = block.Fneu(k,closest_frame_before:closest_frame_after);
+%         spks_stim(k,time,:) = block.spks(k,closest_frame_before:closest_frame_after);
+% 
+%         %df/f
+% %         baseline_mean = mean(F7(closest_frame_before:closest_frame_sound));
+% %         F7_dfF_stim(k,time,:) = (bsxfun(@minus, raw_trace(k,time,:),baseline_mean))./baseline_mean;
+%     end
+% end
+% %  block.aligned_stim.F7_dfF_stim = F7_dfF_stim;
+%  block.aligned_stim.F7_stim = F7_stim;
+%  block.aligned_stim.F_stim = F_stim;
+%  block.aligned_stim.Fneu_stim = Fneu_stim;
+%  block.aligned_stim.spks_stim = spks_stim;
+%  
 
 

--- a/align_to_stim.m
+++ b/align_to_stim.m
@@ -70,26 +70,23 @@ for time=1:length(Sound_Time)
     [~, closest_frame_sound] = min(abs(block.timestamp(:)-sound));
     A = closest_frame_sound - baseline_inFrames;
     B = closest_frame_sound + after_inFrames - 1;
+    b = duration_inFrames;
     
     % loop through each "iscell" to find the stim-aligned 1) raw
     % fluoresence 2) neuropil signal 3) neuropil-corrected floresence 4)
     % df/F for the neuropil corrected fluoresence 5) deconvolved spikes
-    for k = 1:size(block.F,1)
 
-        %If user-defined trial is longer than block recording, take portion
-        %of trial up to the end of recording, the rest of the frames will be nan
-        b = duration_inFrames;
-        B = closest_frame_sound + after_inFrames - 1;
-        if B > size(F7,2)
-            B = size(F7,2);
-            b = length(A:B);
-        end
-        % pull out the frames aligned to a stim (defined in frames)
-        F7_stim(k,time,1:b) = F7(k,A:B);
-        F_stim(k,time,1:b) =  block.F(k,A:B);
-        Fneu_stim(k,time,1:b) = block.Fneu(k,A:B);
-        spks_stim(k,time,1:b) = block.spks(k,A:B);
+    %If user-defined trial is longer than block recording, take portion
+    %of trial up to the end of recording, the rest of the frames will be nan
+    if B > size(F7,2)
+        B = size(F7,2);
+        b = length(A:B);
     end
+    % pull out the frames aligned to a stim (defined in frames)
+    F7_stim(:,time,1:b) = F7(:,A:B);
+    F_stim(:,time,1:b) =  block.F(:,A:B);
+    Fneu_stim(:,time,1:b) = block.Fneu(:,A:B);
+    spks_stim(:,time,1:b) = block.spks(:,A:B);
 end
 
  block.aligned_stim.F7_stim = F7_stim;

--- a/compile_blocks_from_info.m
+++ b/compile_blocks_from_info.m
@@ -235,7 +235,7 @@ for i = 1:size(currentInfo,1)
     [block] = FreqDisc_Behavior_singleblock(block);
 
     %pull out the Bruker-derived timestamps from BOTs and Voltage Recordings
-    [block] = define_sound_singleblock(block,constant);
+    [block] = define_sound_singleblock(block);
 
     %determine which trials are considered "active (locomotor)"
     % This might not be necessary to do here, but leaving in for now.

--- a/compile_blocks_from_info_v2.m
+++ b/compile_blocks_from_info_v2.m
@@ -26,7 +26,7 @@
 %% Load Info.mat and change user-specific options
 
 recompile = 0; %1 to save over previously compiled blocks, 0 to skip
-checkOps = 0; %1 to check Fall.ops against user-specified ops.mat file
+checkOps = 1; %1 to check Fall.ops against user-specified ops.mat file
 
 %% set up values for 'align to stim'
 % Ndnf vs. Vip project: 0.5, 2.5, 1.5, 1.5, 0.8, 0.7
@@ -57,12 +57,12 @@ PC_name = getenv('computername');
 switch PC_name
     case 'RD0366' %Maryse
         info_path = 'D:\Data\2p\VIPvsNDNF_response_stimuli_study';
-        save_path = 'D:\Data\2p\VIPvsNDNF_response_stimuli_study\CompiledBlocks';
+        save_path = 'D:\Data\2p\VIPvsNDNF_response_stimuli_study\CompiledBlocks_v2';
         %info_path = 'D:\Data\2p\VIPvsNDNF_response_stimuli_study\CompiledBlocks_BehaviorStim';
         %save_path = 'D:\Data\2p\VIPvsNDNF_response_stimuli_study\CompiledBlocks_BehaviorStim';
         %info_path = '\\apollo\research\ENT\Takesian Lab\Maryse\2p data\Behavior Pilots';
         %save_path = '\\apollo\research\ENT\Takesian Lab\Maryse\2p data\Behavior Pilots\Compiled Blocks';
-        info_filename = 'Info_widefield';
+        info_filename = 'Info_YE083020F2';
         ops_filename = 'Maryse_ops_thy1.mat';
          
     case 'TAKESIANLAB2P' %2P computer
@@ -122,19 +122,18 @@ for i = 1:size(currentInfo,1)
     setup.expt_date         =   [currentInfo{i,4}];     %part of the path, YYYY-MM-DD
     setup.block_name        =   [currentInfo{i,5}];     %part of the path - full block name used for BOT
     setup.FOV               =   [currentInfo{i,6}];     %which data to consider as coming from the same field of view, per mouse
-    setup.imaging_set       =   [currentInfo{i,7}];     %block or BOT numbers
-    setup.Tosca_session     =   [currentInfo{i,8}];     %Tosca session
-    setup.Tosca_run         =   [currentInfo{i,9}];     %Tosca run
-    setup.analysis_name     =   [currentInfo{i,10}];    %part of the path, folder where fall.mats are stored
-    setup.run_redcell       =   [currentInfo{i,11}];    %do you have red cells? 0 or 1
-    setup.VR_name           =   [currentInfo{i,12}];    %full voltage recording name (if widefield only)
-    setup.stim_name         =   [currentInfo{i,13}];    %type of stim presentation in plain text
-    setup.stim_protocol     =   [currentInfo{i,14}];    %number corresponding to stim protocol
-    setup.gcamp_type        =   [currentInfo{i,15}];    %f, m, or s depending on GCaMP type
-    setup.expt_group        =   [currentInfo{i,16}];    %name of experimental group or condition
-    setup.imaging_depth     =   [currentInfo{i,17}];    %imaging depth in microns
-    setup.after_stim        =   [currentInfo{i,18}];    %overwrite constant.after_stim
-     
+    setup.Tosca_session     =   [currentInfo{i,7}];     %Tosca session
+    setup.Tosca_run         =   [currentInfo{i,8}];     %Tosca run
+    setup.analysis_name     =   [currentInfo{i,9}];    %part of the path, folder where fall.mats are stored
+    setup.run_redcell       =   [currentInfo{i,10}];    %do you have red cells? 0 or 1
+    setup.VR_name           =   [currentInfo{i,11}];    %full voltage recording name (if widefield only)
+    setup.stim_name         =   [currentInfo{i,12}];    %type of stim presentation in plain text
+    setup.stim_protocol     =   [currentInfo{i,13}];    %number corresponding to stim protocol
+    setup.gcamp_type        =   [currentInfo{i,14}];    %f, m, or s depending on GCaMP type
+    setup.expt_group        =   [currentInfo{i,15}];    %name of experimental group or condition
+    setup.imaging_depth     =   [currentInfo{i,16}];    %imaging depth in microns
+    setup.after_stim        =   [currentInfo{i,17}];    %overwrite constant.after_stim
+ 
     if ~ismissing(setup.after_stim)
         setup.constant.after_stim = setup.after_stim;
     end
@@ -143,6 +142,14 @@ for i = 1:size(currentInfo,1)
         FOVtag = ['_FOV' setup.FOV{1}];
     else
         FOVtag = '';
+    end
+
+    if ~ismissing(setup.block_name)
+        block_number = setup.block_name{1}(1,end-2:end);
+        setup.imaging_set = str2double(block_number);
+        blockTag = ['_Block' block_number];
+    else
+        blockTag = '';
     end
     
     if ~ismissing(setup.VR_name)
@@ -153,9 +160,10 @@ for i = 1:size(currentInfo,1)
     
     setup.block_filename = strcat('Compiled_', setup.mousename, FOVtag, '_', setup.expt_date, ...
         '_Session', sprintf('%02d',setup.Tosca_session), '_Run', sprintf('%02d',setup.Tosca_run),...
-        '_Block', sprintf('%03d',setup.imaging_set), '_', widefieldTag, setup.stim_name);
+        blockTag, '_', widefieldTag, setup.stim_name);
     setup.block_supname = strcat(setup.mousename, '-', FOVtag, '-', setup.expt_date, ...
-        '-', setup.stim_name, '-', sprintf('%03d',setup.imaging_set));
+        '-', setup.stim_name, '-Session', sprintf('%02d',setup.Tosca_session), '-Run', sprintf('%02d',setup.Tosca_run),...
+        '-Block', block_number);
     
     %Skip files that have previously been compiled
     if ~recompile

--- a/compile_blocks_from_info_v2.m
+++ b/compile_blocks_from_info_v2.m
@@ -1,4 +1,4 @@
-%% compile_blocks_from_info
+%% compile_blocks_from_info_v2
 %
 %  This script saves a compiled 'block.mat' file for each row in Info.
 %  A compiled block contains Suite2p, Bruker, and Tosca data.
@@ -17,15 +17,14 @@
 %  - define_loco_singleblock
 %  - define_suite2p_singleblock
 %  - align_to_stim
-%  - visualize_block
 %    
-%  Use visualize_block to preview the block contents once they've been compiled.
+%  Use visualize_block and visualize_cell to preview the block contents once they've been compiled.
 %
 %  TAKESIAN LAB - March 2020
+%  v2 December 2020 saves blocks with new naming system
 
 %% Load Info.mat and change user-specific options
 
-visualize = 0; %1 to plot figures of the block immediately, 0 to skip
 recompile = 1; %1 to save over previously compiled blocks, 0 to skip
 checkOps = 0; %1 to check Fall.ops against user-specified ops.mat file
 
@@ -35,6 +34,7 @@ checkOps = 0; %1 to check Fall.ops against user-specified ops.mat file
 constant.baseline_length = 0.5;
 
 % How many seconds after stim should we look at?
+% Can be overwritten by column in info
 constant.after_stim = 2.5;
 
 % Define (in seconds) where to look for the response peak?
@@ -101,16 +101,7 @@ end
 
 %% Compile all blocks unless they are set to "Ignore"
 %  No need to change any variables below this point
-
-%Add extra empty columns when updates might be ahead of people's Info sheets
-lastColumn = 19; %WARNING: Magic number
-if size(Info,2) < lastColumn
-    for i = (size(Info,2) + 1):lastColumn
-        Info{1,i} = 'Expand Columns';
-    end
-    warning('gcamp_type and expt_group columns missing from Info')
-end
-        
+ 
 %Remove header from Info
 Info(1,:) = [];
 
@@ -126,23 +117,22 @@ for i = 1:size(currentInfo,1)
     setup.constant          =   constant;
     setup.Info              =   Info;                   %Record Info for records only
     setup.pathname          =   [currentInfo{i,2}];     %first part of the path
-    setup.username          =   [currentInfo{i,3}];     %part of the path, not every user will have this, okay to leave empty
-    setup.mousename         =   [currentInfo{i,4}];     %part of the path, no underscores
-    setup.expt_date         =   [currentInfo{i,5}];     %part of the path, YYYY-MM-DD
-    setup.block_name        =   [currentInfo{i,6}];     %part of the path - full block name used for BOT
-    setup.FOV               =   [currentInfo{i,7}];     %which data to consider as coming from the same field of view, per mouse
-    setup.imaging_set       =   [currentInfo{i,8}];     %block or BOT numbers
-    setup.Tosca_session     =   [currentInfo{i,9}];     %Tosca session
-    setup.Tosca_run         =   [currentInfo{i,10}];    %Tosca run
-    setup.analysis_name     =   [currentInfo{i,11}];    %part of the path, folder where fall.mats are stored
-    setup.framerate         =   [currentInfo{i,12}];    %15 or 30, eventually we can detect this automatically
-    setup.run_redcell       =   [currentInfo{i,13}];    %do you have red cells? 0 or 1
-    setup.voltage_recording =   [currentInfo{i,14}];    %0 for widefield, 1 for 2p
-    setup.VR_name           =   [currentInfo{i,15}];    %full voltage recording name (if widefield only)
-    setup.stim_name         =   [currentInfo{i,16}];    %type of stim presentation in plain text
-    setup.stim_protocol     =   [currentInfo{i,17}];    %number corresponding to stim protocol
-    setup.gcamp_type        =   [currentInfo{i,18}];    %f, m, or s depending on GCaMP type
-    setup.expt_group        =   [currentInfo{i,19}];    %name of experimental group or condition
+    setup.mousename         =   [currentInfo{i,3}];     %part of the path, no underscores
+    setup.expt_date         =   [currentInfo{i,4}];     %part of the path, YYYY-MM-DD
+    setup.block_name        =   [currentInfo{i,5}];     %part of the path - full block name used for BOT
+    setup.FOV               =   [currentInfo{i,6}];     %which data to consider as coming from the same field of view, per mouse
+    setup.imaging_set       =   [currentInfo{i,7}];     %block or BOT numbers
+    setup.Tosca_session     =   [currentInfo{i,8}];     %Tosca session
+    setup.Tosca_run         =   [currentInfo{i,9}];     %Tosca run
+    setup.analysis_name     =   [currentInfo{i,10}];    %part of the path, folder where fall.mats are stored
+    setup.framerate         =   [currentInfo{i,11}];    %15 or 30, eventually we can detect this automatically
+    setup.run_redcell       =   [currentInfo{i,12}];    %do you have red cells? 0 or 1
+    setup.voltage_recording =   [currentInfo{i,13}];    %0 for widefield, 1 for 2p
+    setup.VR_name           =   [currentInfo{i,14}];    %full voltage recording name (if widefield only)
+    setup.stim_name         =   [currentInfo{i,15}];    %type of stim presentation in plain text
+    setup.stim_protocol     =   [currentInfo{i,16}];    %number corresponding to stim protocol
+    setup.gcamp_type        =   [currentInfo{i,17}];    %f, m, or s depending on GCaMP type
+    setup.expt_group        =   [currentInfo{i,18}];    %name of experimental group or condition
     
     Block_number = sprintf('%03d',setup.imaging_set);
     

--- a/define_behavior_singleblock.m
+++ b/define_behavior_singleblock.m
@@ -198,6 +198,9 @@ for t=1:length(inblock) %Hypothesis is trial 00 is generated abberantly, so star
             else
                 b_Outcome{t}=NaN;
                 trialType{t}=NaN;
+                if setup.stim_protocol == 13
+                    targetFreq(t) = Data{t}.Target_kHz;
+                end
                 
             end
         catch

--- a/define_behavior_singleblock.m
+++ b/define_behavior_singleblock.m
@@ -347,17 +347,27 @@ for j=1:length(Data)
     end
 end
 error_trials=cell2mat(error_trials);
-~isnan(error_trials);
 k = find(error_trials>0);
-block.errors = k;
 if ~isempty(k)
-
-warning(['Found ' num2str(length(k)) ' error(s) out of ' num2str(length(error_trials)) ' Tosca trials'])
-
-    New_sound_times(:,k)=[];
+    start_time(:,k) = [];
+    Tosca_times(:,k)  = [];
+    New_sound_times(:,k) = [];
+    licks(k,:) = [];
+    b_Outcome(:,k) = [];
+    trialType(:,k) = [];
+    if ~isnan(targetFreq)
+        targetFreq(:,k) = [];
+    end
+    zero_loc(:,k) = [];
+    activity_trial(:,k) = [];
+    rxn_time(:,k) = [];
+    locTrial_idx(:,k) = [];
     if setup.stim_protocol>=2
         V1(:,k)=[];
         V2(:,k)=[];
+    end
+    if setup.stim_protocol == 13
+    	holdingPeriod(:,k) = [];
     end
 end
 
@@ -368,14 +378,15 @@ Var2=[Var2,V2];
 %Format used to be: data.([mouseID]).(['ImagingBlock' Imaging_Num]).VARIABLE
 %And: data.([mouseID]).parameters
 
-block.New_sound_times = New_sound_times;
 block.start_time = start_time;
-block.lick_time = licks;
 block.Tosca_times = Tosca_times;
+block.errors = k;
+block.New_sound_times = New_sound_times;
+block.lick_time = licks;
 block.Outcome =  cell2mat(b_Outcome);
 block.trialType = cell2mat(trialType);
 block.TargetFreq = targetFreq;
-block.parameters.variable1 = Var1; %index of variable1 (e.g. frequency)
+block.parameters.variable1 = Var1; %index of variable 1 (e.g. frequency)
 block.parameters.variable2 = Var2; %index of variable 2 (e.g. level)
 block.loco_data = loco_data; %raw loco data
 block.loco_activity = loco_trace_activity; %trace of velocity

--- a/define_sound_singleblock.m
+++ b/define_sound_singleblock.m
@@ -1,4 +1,4 @@
-function [block] = define_sound_singleblock(block,constant)
+function [block] = define_sound_singleblock(block)
 % DOCUMENTATION IN PROGRESS
 % 
 % This function obtains the Bruker timestamp from the BOT and VR csv files,
@@ -25,7 +25,6 @@ function [block] = define_sound_singleblock(block,constant)
 % Variables needed from block.setup:
 % -block_path
 % -VR_path
-% -voltage_recording
 % -stim_protocol
 %
 % Uses the function:
@@ -49,6 +48,7 @@ end
 disp('Pulling out Bruker data...');
 
 setup = block.setup;
+constant = block.setup.constant;
 
 %% Go to block and VR folders and pull out BOT and voltage recording files
 
@@ -58,7 +58,7 @@ setup = block.setup;
 %now lets get the relevant data from Voltage recording. This is when Tosca
 %sends a 5V burst to the Bruker system. The first time this occurs is t=0 on Tosca
 
-if setup.stim_protocol == 4 || setup.voltage_recording == 0
+if ~ismissing(setup.VR_name)
     cd(setup.VR_path) %Widefield
 else
     cd(setup.block_path) %2p
@@ -160,6 +160,52 @@ timestamp = frame_data(:,1)-frame_data(1,1);% this is where we make that small c
 block.timestamp = timestamp;
 block.active_trials = active_trials;
 block.locomotion_trace = locomotion_trace;
+
+%Read XML file
+disp('Reading XML file')
+XML_files = filenames(contains(filenames,'.xml'));
+X = xml2struct(XML_files{1});
+
+if ~ismissing(setup.VR_name) %widefield
+    XML = struct;
+    XML.activeMode = X.PVScan.PVStateShard.PVStateValue{1, 1}.Attributes.value;
+    XML.camera_binFactor = X.PVScan.PVStateShard.PVStateValue{1, 3}.Attributes.value;
+    XML.camera_exposureMode = X.PVScan.PVStateShard.PVStateValue{1, 4}.Attributes.value;
+    XML.camera_exposureTime = X.PVScan.PVStateShard.PVStateValue{1, 5}.Attributes.value;
+    XML.dwellTime = X.PVScan.PVStateShard.PVStateValue{1, 9}.Attributes.value;
+    XML.framePeriod = X.PVScan.PVStateShard.PVStateValue{1, 10}.Attributes.value;
+    XML.opticalZoom = X.PVScan.PVStateShard.PVStateValue{1, 21}.Attributes.value;
+    
+    framerate = round(1/str2double(XML.framePeriod));
+    if framerate ~= 20
+        warning('Check frame rate')
+    end
+    
+else %2p
+    XML = struct;
+    XML.filename = XML_files{1};
+    XML.activeMode = X.PVScan.PVStateShard.PVStateValue{1, 1}.Attributes.value;
+    XML.dwellTime = X.PVScan.PVStateShard.PVStateValue{1, 5}.Attributes.value;
+    XML.framePeriod = X.PVScan.PVStateShard.PVStateValue{1, 6}.Attributes.value;
+    XML.laserPower = X.PVScan.PVStateShard.PVStateValue{1, 8}.IndexedValue{1, 1}.Attributes.value;
+    XML.laserWavelength = X.PVScan.PVStateShard.PVStateValue{1, 9}.IndexedValue.Attributes.value;
+    XML.PMT1_Gain = X.PVScan.PVStateShard.PVStateValue{1, 19}.IndexedValue{1, 1}.Attributes.value;
+    XML.PMT2_Gain = X.PVScan.PVStateShard.PVStateValue{1, 19}.IndexedValue{1, 2}.Attributes.value;
+    XML.linesPerFrame = X.PVScan.PVStateShard.PVStateValue{1, 10}.Attributes.value;
+    XML.micronsPerPixelX = X.PVScan.PVStateShard.PVStateValue{1, 12}.IndexedValue{1, 1}.Attributes.value;
+    XML.micronsPerPixelY = X.PVScan.PVStateShard.PVStateValue{1, 12}.IndexedValue{1, 2}.Attributes.value;
+    XML.opticalZoom = X.PVScan.PVStateShard.PVStateValue{1, 17}.Attributes.value;
+    
+    framerate = round(1/str2double(XML.framePeriod));
+    if framerate ~= 15 && framerate ~= 30
+        warning('Check frame rate')
+    end
+end
+
+%Record XML data
+setup.XML = XML;
+setup.framerate = framerate;
+disp(['Framerate: ' num2str(framerate)])
 
 %Record filenames
 setup.VR_filename = VR_filename;

--- a/define_sound_singleblock.m
+++ b/define_sound_singleblock.m
@@ -163,7 +163,7 @@ block.locomotion_trace = locomotion_trace;
 
 %Read XML file
 disp('Reading XML file')
-XML_files = filenames(contains(filenames,'.xml'));
+XML_files = filenames(contains(filenames,'.xml'));  
 X = xml2struct(XML_files{1});
 
 if ~ismissing(setup.VR_name) %widefield
@@ -176,7 +176,7 @@ if ~ismissing(setup.VR_name) %widefield
     XML.framePeriod = X.PVScan.PVStateShard.PVStateValue{1, 10}.Attributes.value;
     XML.opticalZoom = X.PVScan.PVStateShard.PVStateValue{1, 21}.Attributes.value;
     
-    framerate = round(1/str2double(XML.framePeriod));
+    framerate = ceil(1/str2double(XML.framePeriod));
     if framerate ~= 20
         warning('Check frame rate')
     end
@@ -196,7 +196,7 @@ else %2p
     XML.micronsPerPixelY = X.PVScan.PVStateShard.PVStateValue{1, 12}.IndexedValue{1, 2}.Attributes.value;
     XML.opticalZoom = X.PVScan.PVStateShard.PVStateValue{1, 17}.Attributes.value;
     
-    framerate = round(1/str2double(XML.framePeriod));
+    framerate = ceil(1/str2double(XML.framePeriod));
     if framerate ~= 15 && framerate ~= 30
         warning('Check frame rate')
     end

--- a/define_suite2p_singleblock.m
+++ b/define_suite2p_singleblock.m
@@ -70,6 +70,11 @@ end
 
 block.ops = get_abridged_ops(Fall.ops);
 
+%Check that neucoeff matches block.ops.neucoeff
+if ~isequal(block.setup.constant.neucoeff, block.ops.neucoeff)
+    warning(['User neucoeff (' num2str(block.setup.constant.neucoeff) ') does not match Suite2p neucoeff (' num2str(block.ops.neucoeff) ')'])
+end
+
 if checkOps
     unmatchingOps = [];
     userOps = [];

--- a/ops_maryse.m
+++ b/ops_maryse.m
@@ -17,7 +17,7 @@
 %% Save filepath
 
 filepath = 'D:/Data/2p/VIPvsNDNF_response_stimuli_study';
-filename = 'Maryse_ops2.mat';
+filename = 'Maryse_ops_thy1.mat';
 
 ops = struct;
 
@@ -31,7 +31,7 @@ ops.bruker = 0;
 ops.nplanes = 1;
 ops.nchannels = 1;
 ops.functional_chan = 1;
-ops.tau = 0.7;
+ops.tau = 1.5;
 ops.fs = 30;
 ops.do_bidiphase = 1;
 ops.bidiphase = 0;

--- a/visualize_block.m
+++ b/visualize_block.m
@@ -288,7 +288,7 @@ else
                 img = block.img.refImg;
                 %img = block.img.meanImg;
                 image(img);
-                if block.setup.voltage_recording == 0
+                if ismissing(block.setup.VR_name)
                     imagesc(img);
                 end
             elseif m == 2 


### PR DESCRIPTION
I updated our compile_blocks scripts with some changes Carolyn and I had been talking about making for awhile. This will change the columns in the info spreadsheet and the naming format for block files. To use the new format run compile_blocks_from_info_v2

New naming format:
Compiled_YE083020F1_FOV2x_2020-11-10_Session04_Run02_Block002_behaviorStim

Changes to info spreadsheets:
1. Delete user column
2. Delete imaging set column, this is now taken from block_name
3. Delete frame rate column, this is now pulled from the XML file
4. Delete voltage_recording column, will now identify widefield by whether VR_name is present
5. Add a column at the end called imaging_depth = imaging depth in microns. New field for us to record imaging depth for all experiments. Can leave blank until you’re ready to fill in (but add header)
6. Add another column at the end called after_stim (this can stay empty but add header). It is used to overwrite constant.after_stim if you have a different stim duration.

Other changes I made were to extract information from the .xml file for each block and save in block.setup.XML. Reading the XML file definitely adds time to compiling (~30-45 seconds per block). This could be shortened if we figured out how to pull specific information from the XML instead of reading the full file.

In align_to_stim, the way trials were being extracted led to trial durations being off by a frame at times. I changed this so that trials are preallocated to be a specific frame length base on our framerate. This should hopefully lead to all trials being the same duration across blocks.
