### PR TITLE
Update widefield and analysis scripts to use new compile blocks format

### DIFF
--- a/analysis_2P_v3.m
+++ b/analysis_2P_v3.m
@@ -44,10 +44,9 @@ else
     switch PC_name
         case 'RD0366' %Maryse
             info_path = 'D:/Data/2p/VIPvsNDNF_response_stimuli_study';
-            %compiled_blocks_path = 'D:/Data/2p/VIPvsNDNF_response_stimuli_study/CompiledBlocks';
-            compiled_blocks_path = '\\apollo\research\ENT\Takesian Lab\Carolyn\2P Imaging data\analyzed\Daily_Imaging';
+            compiled_blocks_path = 'D:/Data/2p/VIPvsNDNF_response_stimuli_study/CompiledBlocks_v2';
             save_path = 'D:/Data/2p/VIPvsNDNF_response_stimuli_study';
-            info_filename = 'Info_VxAC031419M1';
+            info_filename = 'Info_YE083020F1';
         case 'RD0332' %Carolyn
             info_path = 'D:\2P analysis\2P local data\Carolyn';
 %             compiled_blocks_path = 'D:\2P analysis\2P local data\Carolyn\analyzed\Daily Imaging';
@@ -65,7 +64,8 @@ else
     Info = importfile(info_filename);
 
     %Create data structure for files corresponding to stim_protocol
-    [data] = fillSetupFromInfoTable_v2(Info, compiled_blocks_path, stim_protocol);
+    [data] = fillSetupFromInfoTable_v3(Info, compiled_blocks_path, stim_protocol);
+    %[data] = fillSetupFromInfoTable_v2(Info, compiled_blocks_path, stim_protocol); Use V2 for old compile_blocks format
     data.setup.run_redcell = run_redcell;
 end
 

--- a/analysis_widefield_gcamp_v2.m
+++ b/analysis_widefield_gcamp_v2.m
@@ -73,7 +73,8 @@ else
     Info = importfile(info_filename);
     
     %Create data structure for files corresponding to stim_protocol
-    [data] = fillSetupFromInfoTable_v2(Info, compiled_blocks_path, stim_protocol);
+    [data] = fillSetupFromInfoTable_v3(Info, compiled_blocks_path, stim_protocol);
+    %[data] = fillSetupFromInfoTable_v2(Info, compiled_blocks_path, stim_protocol); Use V2 for old compile_blocks format
     data.setup.imaging_chan = imaging_chan;
     data.setup.BOT_start = BOT_start;
     

--- a/compile_blocks_from_info_v2.m
+++ b/compile_blocks_from_info_v2.m
@@ -26,7 +26,7 @@
 %% Load Info.mat and change user-specific options
 
 recompile = 0; %1 to save over previously compiled blocks, 0 to skip
-checkOps = 1; %1 to check Fall.ops against user-specified ops.mat file
+checkOps = 0; %1 to check Fall.ops against user-specified ops.mat file
 
 %% set up values for 'align to stim'
 % Ndnf vs. Vip project: 0.5, 2.5, 1.5, 1.5, 0.8, 0.7
@@ -57,12 +57,12 @@ PC_name = getenv('computername');
 switch PC_name
     case 'RD0366' %Maryse
         info_path = 'D:\Data\2p\VIPvsNDNF_response_stimuli_study';
-        save_path = 'D:\Data\2p\VIPvsNDNF_response_stimuli_study\CompiledBlocks_v2';
+        save_path = 'D:\Data\2p\VIPvsNDNF_response_stimuli_study\CompiledWidefieldBlocks';
         %info_path = 'D:\Data\2p\VIPvsNDNF_response_stimuli_study\CompiledBlocks_BehaviorStim';
         %save_path = 'D:\Data\2p\VIPvsNDNF_response_stimuli_study\CompiledBlocks_BehaviorStim';
         %info_path = '\\apollo\research\ENT\Takesian Lab\Maryse\2p data\Behavior Pilots';
         %save_path = '\\apollo\research\ENT\Takesian Lab\Maryse\2p data\Behavior Pilots\Compiled Blocks';
-        info_filename = 'Info_YE083020F2';
+        info_filename = 'Info_widefield';
         ops_filename = 'Maryse_ops_thy1.mat';
          
     case 'TAKESIANLAB2P' %2P computer
@@ -109,6 +109,10 @@ Info(1,:) = [];
 %Remove rows that are set to "Ignore"
 ignore = [Info{:,1}]';
 currentInfo = Info(ignore == 0,:);
+
+if isempty(currentInfo)
+    error('No data found to compile. Check Info sheet.')
+end
 
 %Loop through all remaining rows
 for i = 1:size(currentInfo,1)

--- a/crop_window.m
+++ b/crop_window.m
@@ -15,7 +15,7 @@ for a=1:size(setup.mousename,1) %Mice
     for i=1:length(Imaging_Block)
         unique_block_name = setup.unique_block_names{a,b}(i);
         block = data.([mouseID]).([unique_block_name]);
-        folder = convertStringsToChars(setup.BOTpath);
+        folder = block.setup.block_path; %convertStringsToChars(setup.BOTpath);
         
         %how many tiffs do we need to load?
         tiffnum = length(block.timestamp);

--- a/df_F.m
+++ b/df_F.m
@@ -36,7 +36,8 @@ for a=1:size(setup.mousename,1) %Mice
         unique_block_name = setup.unique_block_names{a,b}(1);
      % settings for trace window
         constants = data.([mouseID]).([unique_block_name]).setup.constant;
-        FrameRate = unique(setup.FrameRate{a,b});
+        FrameRate = data.([mouseID]).([unique_block_name]).setup.framerate;
+        %FrameRate = unique(setup.FrameRate{a,b}); %OLD WAY TO GET FRAME RATE
         
         if length(FrameRate) > 1
             error('Not all frame rates are the same.')

--- a/fillSetupFromInfoTable_v3.m
+++ b/fillSetupFromInfoTable_v3.m
@@ -1,4 +1,4 @@
-function [data] = fillSetupFromInfoTable_v2(Info, compiled_blocks_path, stim_protocol)
+function [data] = fillSetupFromInfoTable_v3(Info, compiled_blocks_path, stim_protocol)
 % This function creates a data.mat file with all of the block data for 
 % a given experiment specified by Info
 % 
@@ -11,7 +11,7 @@ function [data] = fillSetupFromInfoTable_v2(Info, compiled_blocks_path, stim_pro
 %   data(struct)
 % 
 % Notes:
-%
+%   v3 January 2021 uses blocks saved with compile_blocks_from_info_v2
 %
 % TODO: allow stim_protocol to take a list of stims instead of just one
 % Search 'TODO'
@@ -20,24 +20,20 @@ function [data] = fillSetupFromInfoTable_v2(Info, compiled_blocks_path, stim_pro
 
 %  Currently, the column order of Info is:
 I = 1; %ignore (0 or 1 allowing user to "hide" some files from analysis)
-P = 2; %first part of the path
-U = 3; %part of the path, not every user will have this, okay to leave empty
-M = 4; %part of the path, no underscores
-D = 5; %part of the path, YYYY-MM-DD
-B = 6; %part of the path - full block name used for BOT
-F = 7; %which data to consider as coming from the same FOV, per mouse
-IS = 8; %block or BOT numbers
-TS = 9; %Tosca session #
-TR = 10; %Tosca run #
-AP = 11; %part of the path, folder where fall.mats are stored
-FR = 12; %15 or 30, eventually we can detect this automatically
-RR = 13; %do you have red cells? 0 or 1 %Not used right now
-VR = 14; %voltage recording (0 for widefield, 1 for 2p)
-VN = 15; %full voltage recording name (if widefield only)
-SN = 16; %type of stim presentation in plain text
-SP = 17; %stim protocol (number corresponding to stim)
-GT = 18; %f, m, or s depending on GCaMP type
-EG = 19; %name of experimental group or condition
+P = 2; %pathname
+M = 3; %mouse name
+D = 4; %experiment date
+B = 5; %block name
+F = 6; %FOV
+TS = 7; %Tosca session #
+TR = 8; %Tosca run #
+AP = 9; %part of the path, folder where fall.mats are stored
+RR = 10; %do you have red cells? 0 or 1 %Not used right now
+VN = 11; %full voltage recording name (if widefield only)
+SN = 12; %type of stim presentation in plain text
+SP = 13; %stim protocol (number corresponding to stim)
+GT = 14; %f, m, or s depending on GCaMP type
+EG = 15; %name of experimental group or condition
 
 %% We will be looking for files that match stim_protocol
 %Later we could update this to also look for other parameters
@@ -61,6 +57,16 @@ disp(['Analyzing ' code{stim_protocol} ' files'])
 
 Info(1,:) = []; %Remove header from Info
 
+%Add Imaging_set (block #) to Info to be back-compatible with analysis scripts
+IS = size(Info,2) + 1;
+for i = 1:size(Info,1)
+    if ~ismissing(Info{i,B})
+        block_name = Info{i,B}{1};
+        Info{i,IS} = str2double(block_name(1,end-2:end));
+    end
+end
+
+%Set up data
 data = struct;
 data.setup = struct;
 data.setup.stim_protocol = stim_protocol;
@@ -98,65 +104,58 @@ for i = 1:length(uniqueMice)
     matching_mice = strcmp(currentMouse, mice);
     
     currentInfo_M = currentInfo(matching_mice,:);
-    FOVs = [currentInfo_M{:,F}]'; %This requires every block to have an FOV number, which corresponds
-    %to which data was run together in Suite2p. If left empty there will be an error
+    FOVs = [currentInfo_M{:,F}]'; %The FOV corresponds to which data was run together in Suite2p.
+    %If left empty it will be NAN and all NANs will be treated as separate FOVs
     uniqueFOVs = unique(FOVs);
     
     for j = 1:length(uniqueFOVs)
         currentFOV = uniqueFOVs(j);
-        currentInfo_R = currentInfo_M(FOVs == currentFOV,:); 
-        
-        try
-            gcamp_type = [currentInfo_R{:,GT}];
-        catch
-            gcamp_type = nan;
+        if ismissing(currentFOV)
+            currentInfo_F = currentInfo_M(j,:);
+        else
+            currentInfo_F = currentInfo_M(FOVs == currentFOV,:); 
         end
         
-        try
-            expt_group = [currentInfo_R{:,EG}];
-        catch
-            expt_group = nan;
-        end
-
         %Fill setup with structure {Mouse, FOV}
         setup.mousename{i,j}         =   currentMouse;
         setup.FOVs{i,j}              =   currentFOV;
-        setup.gcamp_type{i,j}        =   gcamp_type;
-        setup.expt_group{i,j}        =   expt_group;
-        setup.expt_date{i,j}         =   [currentInfo_R{:,D}];
-        setup.Imaging_sets{i,j}      =   [currentInfo_R{:,IS}];
-        setup.Session{i,j}           =   [currentInfo_R{:,TS}];
-        setup.Tosca_Runs{i,j}        =   [currentInfo_R{:,TR}];
-        setup.FrameRate{i,j}         =   [currentInfo_R{:,FR}] 
+        setup.stim_name{i,j}         =   [currentInfo_F{:,SN}];
+        setup.expt_date{i,j}         =   [currentInfo_F{:,D}];
+        setup.block_name{i,j}        =   [currentInfo_F{:,B}];
+        setup.Imaging_sets{i,j}      =   [currentInfo_F{:,IS}];
+        setup.Session{i,j}           =   [currentInfo_F{:,TS}];
+        setup.Tosca_Runs{i,j}        =   [currentInfo_F{:,TR}];
                 
-        block_filenames = cell(1,size(currentInfo_R,1));
-        unique_block_names = cell(1,size(currentInfo_R,1));
-        path_name =currentInfo_R{:,P};
+        %Preallocate variables to record filenames
+        block_filenames = cell(1,size(currentInfo_F,1));
+        unique_block_names = cell(1,size(currentInfo_F,1));
         
-        for r = 1:size(currentInfo_R,1)
+        %Build and record filenames
+        for f = 1:size(currentInfo_F,1)
+
+            if ~ismissing(setup.FOVs{i,j})
+                FOVtag = strcat('_FOV', setup.FOVs{i,j});
+            else
+                FOVtag = '';
+            end
             
-            Block_number = sprintf('%03d',currentInfo_R{r,IS});
-  
-            if currentInfo_R{r,VR} == 0
+            block_name = setup.block_name{i,j}{f};
+            blockTag = ['_Block' block_name(1,end-2:end)];
+            
+            if ~ismissing(currentInfo_F{:,VN})
                 widefieldTag = 'widefield-';
-                setup.VRname = [currentInfo_R{:,VN}];
-                setup.BOTname = [currentInfo_R{:,B}];
-                setup.VRpath = strcat(path_name, '/', currentMouse, '/', setup.expt_date{i,j}, '/', setup.VRname); 
-                setup.BOTpath = strcat(path_name, '/', currentMouse, '/', setup.expt_date{i,j}, '/', setup.BOTname); 
-                
-                
             else
                 widefieldTag = '';
             end
-    
-            block_filenames{1,r} = strcat('Compiled_', currentMouse, '_', [currentInfo_R{r,D}], ...
-            '_Block_', Block_number, '_Session_', num2str([currentInfo_R{r,TS}]), ...
-            '_Run_', num2str([currentInfo_R{r,TR}]), '_', widefieldTag, [currentInfo_R{r,SN}]);
+
+            block_filenames{1,f} = strcat('Compiled_', setup.mousename{i,j}, FOVtag, '_', setup.expt_date{i,j}{f}, ...
+                '_Session', sprintf('%02d',setup.Session{i,j}(f)), '_Run', sprintf('%02d',setup.Tosca_Runs{i,j}(f)),...
+                 blockTag, '_', widefieldTag, setup.stim_name{i,j}{f});
             
-            load(block_filenames{1,r})
+            load(block_filenames{1,f})
         
-            unique_block_names{1,r} = strcat('Block', num2str([currentInfo_R{r,IS}]),...
-                '_Session', num2str([currentInfo_R{r,TS}]), '_Run', num2str([currentInfo_R{r,TR}]));
+            unique_block_names{1,f} = strcat('Block', num2str([currentInfo_F{f,IS}]),...
+                '_Session', num2str([currentInfo_F{f,TS}]), '_Run', num2str([currentInfo_F{f,TR}]));
 
             if isfield(block, 'parameters')
                 data.([currentMouse]).parameters = block.parameters; %This will be written over every time
@@ -165,7 +164,7 @@ for i = 1:length(uniqueMice)
             else
                 block.parameters = nan;
             end
-            data.([currentMouse]).([unique_block_names{1,r}]) = block;
+            data.([currentMouse]).([unique_block_names{1,f}]) = block;
             clear('block');
         end
         setup.block_filename{i,j} = [block_filenames{:,:}];


### PR DESCRIPTION
Created fillSetupFromInfoTable_v3 to replace fillSetupFromInfoTable_v2 in widefield and analysis scripts

To use the old compile blocks format, simply use v2 instead of v3. When ready to start using the new format, you must first recompile all blocks using compile_blocks_from_info_v3